### PR TITLE
Bug NavItem color in big mobile devices

### DIFF
--- a/components/Navigation/NavItems.vue
+++ b/components/Navigation/NavItems.vue
@@ -6,7 +6,7 @@
 </template>
 <style lang="scss">
 .nav-item {
-  @media (max-width: $screen-xs){
+  @media (max-width: $screen-sm) {
     margin-bottom: 2rem;
 
     a {


### PR DESCRIPTION
On large devices like iPhone6/7/8 plus or iPhone X the navItems are not visible